### PR TITLE
Fix reporting for Go 1.11

### DIFF
--- a/unconvert.go
+++ b/unconvert.go
@@ -410,7 +410,7 @@ func (v *visitor) unconvert(call *ast.CallExpr) {
 		return
 	}
 
-	v.edits[v.file.Position(call.Lparen)] = struct{}{}
+	v.edits[v.file.PositionFor(call.Lparen, false)] = struct{}{}
 }
 
 func (v *visitor) isCgoCheckPointerContext() bool {


### PR DESCRIPTION
unconvert output is broken when using Go 1.11. A quick example:

With Go 1.10:

> go run unconvert.go github.com/docker/docker/daemon/graphdriver/copy
> /home/kir/go/src/github.com/docker/docker/daemon/graphdriver/copy/copy.go:242:28: unnecessary conversion

With Go 1.11 beta2:
> go1.11beta2 run unconvert.go github.com/docker/docker/daemon/graphdriver/copy
> copy.go:242:0: unnecessary conversion

Note that file names have path stripped, and column is 0.

The reason is, Go 1.11 changes `go/token`'s `file.Position()` method
(seems that https://github.com/golang/go/commit/99c30211b1e0 is the commit to blame).

The fix is to use `PositionFor(pos, false)` instead.

Fixes #29 