### PR TITLE
Fix file name reporting for Go 1.11 [v2]

### DIFF
--- a/unconvert.go
+++ b/unconvert.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime/pprof"
 	"sort"
@@ -425,7 +426,13 @@ func (v *visitor) unconvert(call *ast.CallExpr) {
 		return
 	}
 
-	v.edits[v.file.Position(call.Lparen)] = struct{}{}
+	pos := v.file.Position(call.Lparen)
+	if !filepath.IsAbs(pos.Filename) { // go 1.11+, see https://github.com/golang/go/issues/26671
+		f := filepath.Base(pos.Filename)
+		d := filepath.Dir(v.file.Name())
+		pos.Filename = filepath.Join(d, f)
+	}
+	v.edits[pos] = struct{}{}
 }
 
 // isFloatingPointer reports whether t's underlying type is a floating


### PR DESCRIPTION
unconvert output for cgo-preprocessed files is broken when using Go 1.11beta. A quick example:

With Go 1.10:

> go run unconvert.go github.com/docker/docker/daemon/graphdriver/copy
> /home/kir/go/src/github.com/docker/docker/daemon/graphdriver/copy/copy.go:242:28: unnecessary conversion

With Go 1.11 beta2:
> go run unconvert.go github.com/docker/docker/daemon/graphdriver/copy
> copy.go:242:0: unnecessary conversion

Note that there are two issues:
 - column is 0;
 - file names have path stripped.

The issue with column is filed as https://github.com/golang/go/issues/26692;
there is no way to fix it in unconvert.

The second issue is currently discussed in
https://github.com/golang/go/issues/26671, but it might not be
fixed since the new documentation says:

> The filenames in line directives now remain untouched by the scanner;
> there is no cleanup or conversion of relative into absolute paths
> anymore, in sync with what the compiler's scanner/parser are doing.
> Any kind of filename transformation has to be done by a client. This
> makes the scanner code simpler and also more predictable.

So, here's the alternative: if the file name is not absolute, prepend
the path as we know it.

Fixes #29