### PR TITLE
unconvert: use x/tools/go/packages

### DIFF
--- a/unconvert.go
+++ b/unconvert.go
@@ -290,9 +290,14 @@ func mergeEdits(importPaths []string) fileToEditSet {
 }
 
 func computeEdits(importPaths []string, osname, arch string, cgoEnabled bool) fileToEditSet {
+	cgoEnabledVal := "0"
+	if cgoEnabled {
+		cgoEnabledVal = "1"
+	}
+
 	pkgs, err := packages.Load(&packages.Config{
 		Mode:  packages.LoadSyntax,
-		Env:   append(os.Environ(), "GOOS="+osname, "GOARCH="+arch),
+		Env:   append(os.Environ(), "GOOS="+osname, "GOARCH="+arch, "CGO_ENABLED="+cgoEnabledVal),
 		Tests: *flagTests,
 	}, importPaths...)
 	if err != nil {


### PR DESCRIPTION
About 2x faster and handles go modules better.

However there are still some [upstream problems with `x/tools/go/packages`](https://github.com/golang/go/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+%22x%2Ftools%2Fgo%2Fpackages%3A%22+). So still need to wait for those fixes. Example issue caused by upstream https://github.com/kisielk/errcheck/issues/150