### PR TITLE
unconvert: fix calling without arguments

### DIFF
--- a/unconvert.go
+++ b/unconvert.go
@@ -218,7 +218,7 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	importPaths := flag.Args()
+	patterns := flag.Args() // 0 or more import path patterns.
 
 	var configs [][]string
 	if *flagConfigs != "" {
@@ -239,7 +239,7 @@ func main() {
 		configs = [][]string{nil}
 	}
 
-	m := mergeEdits(importPaths, configs)
+	m := mergeEdits(patterns, configs)
 
 	if *flagApply {
 		var wg sync.WaitGroup
@@ -291,10 +291,10 @@ func allConfigs() [][]string {
 	return res
 }
 
-func mergeEdits(importPaths []string, configs [][]string) fileToEditSet {
+func mergeEdits(patterns []string, configs [][]string) fileToEditSet {
 	m := make(fileToEditSet)
 	for _, config := range configs {
-		for f, e := range computeEdits(importPaths, config) {
+		for f, e := range computeEdits(patterns, config) {
 			if e0, ok := m[f]; ok {
 				e0.intersect(e)
 			} else {
@@ -305,7 +305,7 @@ func mergeEdits(importPaths []string, configs [][]string) fileToEditSet {
 	return m
 }
 
-func computeEdits(importPaths []string, config []string) fileToEditSet {
+func computeEdits(patterns []string, config []string) fileToEditSet {
 	// TODO(mdempsky): Move into config?
 	var buildFlags []string
 	if *flagTags != "" {
@@ -317,7 +317,7 @@ func computeEdits(importPaths []string, config []string) fileToEditSet {
 		Env:        append(os.Environ(), config...),
 		BuildFlags: buildFlags,
 		Tests:      *flagTests,
-	}, importPaths...)
+	}, patterns...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/unconvert.go
+++ b/unconvert.go
@@ -219,9 +219,6 @@ func main() {
 	}
 
 	importPaths := flag.Args()
-	if len(importPaths) == 0 {
-		return
-	}
 
 	var configs [][]string
 	if *flagConfigs != "" {

--- a/unconvert_test.go
+++ b/unconvert_test.go
@@ -21,9 +21,9 @@ func TestBinary(t *testing.T) {
 	defer cleanup()
 
 	tests := []struct {
-		name    string
-		workdir string
-		args    []string
+		name string
+		dir  string
+		args []string
 	}{
 		{"relative", ".", []string{"./testdata"}},
 		{"dot", "./testdata", []string{"."}},
@@ -34,7 +34,7 @@ func TestBinary(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := exec.Command(exePath, test.args...)
-			cmd.Dir = test.workdir
+			cmd.Dir = test.dir
 
 			output, err := cmd.CombinedOutput()
 			if err == nil {

--- a/unconvert_test.go
+++ b/unconvert_test.go
@@ -28,6 +28,7 @@ func TestBinary(t *testing.T) {
 		{"relative", ".", []string{"./testdata"}},
 		{"dot", "./testdata", []string{"."}},
 		{"no-args", "./testdata", []string{}},
+		{"pattern", "./testdata", []string{"./..."}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
`unconvert` should default to current directory when there are no arguments. Apparently `packages.Load` does it already automatically. Remove the check for no arguments and add tests for the different cases.

Fixes #44 