### PR TITLE
unconvert: update Travis for Go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
+  - 1.x
   - 1.13.x
-  - 1.12.x
   - master
 
 env:


### PR DESCRIPTION
Go 1.14 has been released¹ by now. Start testing against it.

Drop Go 1.12 to maintain coverage for just the last 2 Go releases.

Use the "go1.x" form to refer to the latest stable Go release rather than the "go1.14.x" form, because this form requires less maintenance when new Go releases are made.

¹ https://groups.google.com/d/msg/golang-announce/AYd4cXYG8qk/FPTwU0jPCQAJ